### PR TITLE
ビルドエラーの修正

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ test_script:
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook CalculationSpec\eesCalculationSpec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook CalculationSpec\JJJCalculationSpec.adoc --trace
   - cd asciidoctor-fopub
-  - fopub ..\InterfaceSpec\spec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
+  - gradlew -q -u installApp
   - fopub ..\InterfaceSpec\spec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
   - fopub ..\CalculationSpec\CalculationSpec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
   - fopub ..\CalculationSpec\eesCalculationSpec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,34 +17,35 @@ before_test:
 
 test_script:
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% index.adoc --trace
-  - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% spec.adoc --trace
+  - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% InterfaceSpec\spec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% CalculationSpec\CalculationSpec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% CalculationSpec\eesCalculationSpec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% CalculationSpec\JJJCalculationSpec.adoc --trace
-  - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook spec.adoc --trace
+  - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook InterfaceSpec\spec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook CalculationSpec\CalculationSpec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook CalculationSpec\eesCalculationSpec.adoc --trace
   - asciidoctor -r asciidoctor-diagram -a commit-id=%APPVEYOR_REPO_COMMIT% -b docbook CalculationSpec\JJJCalculationSpec.adoc --trace
   - cd asciidoctor-fopub
-  - fopub ..\spec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
-  - fopub ..\spec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
+  - fopub ..\InterfaceSpec\spec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
+  - fopub ..\InterfaceSpec\spec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
   - fopub ..\CalculationSpec\CalculationSpec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
   - fopub ..\CalculationSpec\eesCalculationSpec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
   - fopub ..\CalculationSpec\JJJCalculationSpec.xml -xsl ..\conf\docbook-config\fo-pdf.xsl
   - cd ..
   - mkdir dist
-  - mkdir dist\images
+  - mkdir dist\InterfaceSpec
+  - mkdir dist\InterfaceSpec\images
   - mkdir dist\CalculationSpec
   - copy index.html dist\index.html
-  - copy spec.html dist\spec.html
-  - copy spec.pdf dist\spec.pdf
+  - copy InterfaceSpec\spec.html dist\InterfaceSpec\spec.html
+  - copy InterfaceSpec\spec.pdf dist\spec.pdf
   - copy CalculationSpec\CalculationSpec.html dist\CalculationSpec\CalculationSpec.html
   - copy CalculationSpec\eesCalculationSpec.html dist\CalculationSpec\eesCalculationSpec.html
   - copy CalculationSpec\JJJCalculationSpec.html dist\CalculationSpec\JJJCalculationSpec.html
   - copy CalculationSpec\CalculationSpec.pdf dist\CalculationSpec.pdf
   - copy CalculationSpec\eesCalculationSpec.pdf dist\eesCalculationSpec.pdf
   - copy CalculationSpec\JJJCalculationSpec.pdf dist\JJJCalculationSpec.pdf
-  - xcopy images dist\images\ /s /e
+  - xcopy InterfaceSpec\images dist\InterfaceSpec\images\ /s /e
 
 artifacts:
 - path: dist
@@ -54,8 +55,8 @@ deploy:
 - provider: FTP
   host: waws-prod-hk1-001.ftp.azurewebsites.windows.net
   protocol: ftps
-  username: jjjdoc\jjjdoc
+  username: jjjdoc\jjjdocftp
   password:
-    secure: G3QJ5qkuXlj46an5IH1+5A==
+    secure: NX1T0Egb4qpWrmZzagRHig==
   folder: site\wwwroot
   application: document

--- a/conf/docbook-config/fo-pdf.xsl
+++ b/conf/docbook-config/fo-pdf.xsl
@@ -36,12 +36,12 @@
     <xsl:param name="fop1.extensions">1</xsl:param>
 
     <xsl:attribute-set name="header.content.properties">
-        <xsl:attribute name="font-family">IPAPGothic</xsl:attribute>
+        <xsl:attribute name="font-family">IPAPGothic,Meiryo</xsl:attribute>
         <xsl:attribute name="font-size">8pt</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="footer.content.properties">
-        <xsl:attribute name="font-family">IPAPGothic</xsl:attribute>
+        <xsl:attribute name="font-family">IPAPGothic,Meiryo</xsl:attribute>
         <xsl:attribute name="font-size">8pt</xsl:attribute>
     </xsl:attribute-set>
 
@@ -68,15 +68,15 @@
     -->
 
     <xsl:template name="pickfont-sans">
-        <xsl:text>IPAPMincho</xsl:text>
+        <xsl:text>IPAPMincho,Meiryo</xsl:text>
     </xsl:template>
 
     <xsl:template name="pickfont-serif">
-        <xsl:text>IPAPGothic</xsl:text>
+        <xsl:text>IPAPGothic,Meiryo</xsl:text>
     </xsl:template>
 
     <xsl:template name="pickfont-mono">
-        <xsl:text>IPAPGothic</xsl:text>
+        <xsl:text>IPAPGothic,Meiryo</xsl:text>
     </xsl:template>
 
     <xsl:template name="pickfont-dingbat">
@@ -84,11 +84,11 @@
     </xsl:template>
 
     <xsl:template name="pickfont-symbol">
-        <xsl:text>IPAPGothic</xsl:text>
+        <xsl:text>IPAPGothic,Meiryo</xsl:text>
     </xsl:template>
 
     <xsl:template name="pickfont-math">
-        <xsl:text>IPAPGothic</xsl:text>
+        <xsl:text>IPAPGothic,Meiryo</xsl:text>
     </xsl:template>
 
     <!--


### PR DESCRIPTION
新しいディレクトリ構成に対応しました。
また、なぜかPDFの日本語出力に失敗していたのでフォントリストにMeiryoを追加しました。

このプルリクエストをマージ後、次のURLに最後のコミット(masterブランチに限らず）に対応したHTMLおよびPDFが生成されます。
http://jjjdoc.azurewebsites.net/

なお、ビルド状態は次のURLから確認できます。
https://ci.appveyor.com/project/WataruUda/jjjprogramspec

また、ビルドが成功しているかの画像が使用できます。
[![Build status](https://ci.appveyor.com/api/projects/status/xhe12tovlafm0kwy?svg=true)](https://ci.appveyor.com/project/WataruUda/jjjprogramspec)